### PR TITLE
Push Back for instant climbing/falling should now work again

### DIFF
--- a/scripts/ArmSwinger.cs
+++ b/scripts/ArmSwinger.cs
@@ -1142,6 +1142,10 @@ public class ArmSwinger : MonoBehaviour {
 
 		previousAngleCheckHeadsetPosition = headsetGameObject.transform.position;
 
+		if (preventionMode == PreventionMode.PushBack) {
+			seedRaycastHitHistory();
+		}
+		
 		//resetOOB();
 		if (preventionMode == PreventionMode.Rewind) {
 			Invoke("resetOOB", rewindFadeInSec);
@@ -1613,6 +1617,16 @@ public class ArmSwinger : MonoBehaviour {
 		headsetCenterRaycastHitHistoryPrevention.Clear();
 	}
 
+	void seedRaycastHitHistory() {
+		bool didRaycastHit = false;
+		RaycastHit raycastHit = raycast(headsetGameObject.transform.position, Vector3.down, raycastMaxLength, raycastGroundLayerMask, out didRaycastHit);
+
+		if (didRaycastHit) {
+			saveRaycastHit(headsetCenterRaycastHitHistoryHeight, raycastHit, 1);
+		}
+
+	}
+
 	void resetRewindPositions() {
 		cameraRigPreviousPositions.Clear();
 		headsetPreviousLocalPositions.Clear();
@@ -1629,7 +1643,8 @@ public class ArmSwinger : MonoBehaviour {
 		resetRewindPositions();
 
 		cameraRigGameObject.transform.position = newPosition;
-		
+
+		seedRaycastHitHistory();
 		outOfBounds = false;
 		currentPreventionReason = PreventionReason.NONE;
 


### PR DESCRIPTION
#22 removed code that wasn't so legacy after all.  The code saved a RaycastHit to seed the height cache just before rewinding.  This fixed an issue where the player could get on top of a too-high stair or wall even if they got pushed back.  Unfortuantely, it also caused the infinite rewind issue in #20.

This commit changes the behavior to work in both instances.  Rather than cache a RaycastHit from just before the push back, we shoot a new Raycast just AFTER making the correction move.  This keeps the player at the right height during the pushback/rewind, prevents climbing too-high surfaces instantly, and doesn't freak out the next instant climb/fall check.

Please report any issues caused by this change - my test cases check out okay.
