### PR TITLE
Fix infinite rewind

### DIFF
--- a/scripts/ArmSwinger.cs
+++ b/scripts/ArmSwinger.cs
@@ -404,7 +404,6 @@ public class ArmSwinger : MonoBehaviour {
 		if (!outOfBounds && !wallClipThisFrame && !rewindThisFrame) {
 			if ((previousCameraRigPositions.Last.Value != cameraRigGameObject.transform.position) ||
 				(previousHeadsetLocalPositions.Last.Value != headsetGameObject.transform.localPosition)) {
-				//Debug.Log(Time.frameCount + "|ArmSwinger.FixedUpdate():: Saving " + cameraRigGameObject.transform.position + headsetGameObject.transform.localPosition);
 
 				savePosition(previousCameraRigPositions, cameraRigGameObject.transform.position, previousPositionSize);
 				savePosition(previousHeadsetLocalPositions, headsetGameObject.transform.localPosition, previousPositionSize);
@@ -940,7 +939,7 @@ public class ArmSwinger : MonoBehaviour {
 				}
 			}
 		} else {
-			triggerRewind(PreventionReason.NO_GROUND);
+			//triggerRewind(PreventionReason.NO_GROUND);
 		}
 	}
 
@@ -1179,8 +1178,6 @@ public class ArmSwinger : MonoBehaviour {
 
 		// Determine what previous positions we need to rewind to
 		determinePreviousPositionToRewindTo(ref cameraRigPreviousPositionToRewindTo, ref headsetPreviousPositionToRewindTo, preventionMode);
-
-		//Debug.Log(Time.frameCount + "|ArmSwinger.rewindPosition():: Mode " + preventionMode + " to " + cameraRigPreviousPositionToRewindTo + headsetPreviousPositionToRewindTo);
 
 		Vector3 newCameraRigPosition = calculateCameraRigRewindPosition(cameraRigPreviousPositionToRewindTo, headsetPreviousPositionToRewindTo, cameraRigGameObject.transform.position, headsetGameObject.transform.localPosition, preventionMode);
 

--- a/scripts/HeadsetCollider.cs
+++ b/scripts/HeadsetCollider.cs
@@ -25,6 +25,10 @@ public class HeadsetCollider : MonoBehaviour {
 
 	private LayerMask groundRayLayerMask;
 
+	// Track previous collision position
+	private Vector3 previousCollisionPosition;
+	private Quaternion previousCollisionRotation;
+
 	//////////////////////
 	// INITIATILIZATION //
 	//////////////////////
@@ -65,6 +69,10 @@ public class HeadsetCollider : MonoBehaviour {
 			}
 		}
 
+		// Initial collision position
+		previousCollisionPosition = this.transform.position;
+		previousCollisionRotation = this.transform.rotation;
+
 		armSwinger = GameObject.FindObjectOfType<ArmSwinger>();
 
 	}
@@ -95,12 +103,22 @@ public class HeadsetCollider : MonoBehaviour {
 
 				foreach (ContactPoint contactPoint in collision.contacts) {
 					Vector3 normalOfCollisionPoint = contactPoint.normal;
+					
 					float angleOfCollisionPoint = Vector3.Angle(Vector3.up, normalOfCollisionPoint);
+
+					//Debug.Log("this.transform=" + this.transform);
+					//Debug.Log("previousCollisionTransform=" + previousCollisionTransform);
+
+					if (this.transform.position == previousCollisionPosition && this.transform.rotation == previousCollisionRotation) {
+						return;
+					}
 
 					if (angleOfCollisionPoint >= minAngleToRewindDueToWallClip) {
 						inGeometry = true;
 						armSwinger.triggerRewind(ArmSwinger.PreventionReason.HEADSET);
 						armSwinger.wallClipThisFrame = true;
+						previousCollisionPosition = this.transform.position;
+						previousCollisionRotation = this.transform.rotation;
 						return;
 					}
 				}


### PR DESCRIPTION
Fixes #42 

Also removed the functionality where a rewind is triggered if the raycast doesn't hit anything.  This could potentially cause infinite rewinds if the floor is adjusted poorly and the raycast shoots under the level.